### PR TITLE
Add simple secret server (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Use a Kubernetes custom metric to enable the Kubernetes Horizontal Pod Autoscale
 ## Simple webserver
 
 Implement a simple static webserver. See [`webserver`](/webserver/).
+
+## Simple secret server
+
+Implement a simple secret server, which takes secrets from `values-secret.yaml` and mounts them in the secretserver container. See [`secretserver`](/secretserver/).

--- a/secretserver/.helmignore
+++ b/secretserver/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/secretserver/Chart.yaml
+++ b/secretserver/Chart.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v2
+name: atestapp
+description: A Test App - Secret server
+type: application
+# chart version
+version: 0.0.1
+# application version
+appVersion: "1.0.0"

--- a/secretserver/Makefile
+++ b/secretserver/Makefile
@@ -1,0 +1,9 @@
+default: docker
+
+.PHONY: docker
+docker:
+	@img="zannen/secretserver" && \
+	ver=$$(python -c 'import yaml; print(yaml.safe_load(open("values.yaml","r"))["secretserverVersion"])') && \
+	cd docker && \
+	echo "Building $$img:$$ver" && \
+	docker build -t "$$img:$$ver" secretserver/

--- a/secretserver/README.md
+++ b/secretserver/README.md
@@ -1,0 +1,50 @@
+# A Kubernetes Secret server
+
+This app is a simple Kubernetes server that serves secrets, using:
+
+* one gunicorn server
+* one Deployment, with one ReplicaSet, with one Pod
+* one Service of type NodePort, with the following ports:
+  * 80 - `targetPort`, accessible from inside the secretserver docker container
+  * 8880 - `port`, accessible from across cluster on the ClusterIP
+  * 30880 - `nodePort`, accessible from outside the cluster
+
+Secrets are taken from `values-secret.yaml` and mounted them in the secretserver container.
+
+# Installing with helm
+
+Get a minikube VM started, then:
+
+```shell
+# Point your shell to minikube's docker-daemon:
+eval $(minikube docker-env)
+
+# Ensure you have a secrets file.
+cp -a values-secret-SAMPLE.yaml values-secret.yaml
+
+# Build the webserver container:
+make docker
+
+helm install atestapp . -n YOUR_NAMESPACE_HERE --create-namespace -f values.yaml -f values-secret.yaml
+```
+
+# Getting secrets
+
+```shell
+curl "http://$(minikube ip):30880/secrets/superSecretPassword1"
+```
+
+# Upgrading with helm
+
+Remember to bump the chart version in `Chart.yaml`, then:
+
+```shell
+helm upgrade atestapp . -n YOUR_NAMESPACE_HERE
+```
+
+# Uninstalling with helm
+
+```shell
+helm uninstall -n YOUR_NAMESPACE_HERE atestapp
+kubectl delete namespace YOUR_NAMESPACE_HERE
+```

--- a/secretserver/README.md
+++ b/secretserver/README.md
@@ -22,7 +22,7 @@ eval $(minikube docker-env)
 # Ensure you have a secrets file.
 cp -a values-secret-SAMPLE.yaml values-secret.yaml
 
-# Build the webserver container:
+# Build the secretserver container:
 make docker
 
 helm install atestapp . -n YOUR_NAMESPACE_HERE --create-namespace -f values.yaml -f values-secret.yaml

--- a/secretserver/docker/secretserver/Dockerfile
+++ b/secretserver/docker/secretserver/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-alpine
+RUN addgroup -g 1000 runner && adduser -g Runner -D -G runner -u 1000 runner
+USER runner
+WORKDIR /home/runner
+ENV FLASK_APP=server FLASK_ENV=development PATH="/home/runner/.local/bin:$PATH" PYTHONPATH=/home/runner
+RUN python -m pip install --user --upgrade pip
+ADD requirements.txt ./
+RUN pip install --user -r requirements.txt
+ADD /app ./app

--- a/secretserver/docker/secretserver/app/__init__.py
+++ b/secretserver/docker/secretserver/app/__init__.py
@@ -1,0 +1,46 @@
+"""
+Provide a Flask app
+"""
+
+import logging
+import os
+import re
+
+import flask
+
+
+def create_app(config={}):
+    """
+    This function is called by gunicorn and creates a Flask app.
+    """
+    app = flask.Flask(__name__)
+    app.config.update(config)
+
+    log_level = os.environ.get("LOGLEVEL", "INFO")
+    logging.basicConfig(format="[%(asctime)-15s] [%(levelname)s] %(message)s")
+    app.logger.setLevel(log_level)
+
+    @app.route("/")
+    def path_root():
+        return {"status": "OK"}, 200
+
+    @app.route("/secrets/<secret_name>")
+    def path_secrets_get(secret_name):
+        err = None
+        secret = ""
+
+        valid_names = re.compile(r"^[a-z][A-Za-z0-9]*$")
+        if valid_names.match(secret_name):
+            try:
+                with open(f"/var/run/passwords/{secret_name}", "r") as fh:
+                    secret = fh.read()
+            except FileNotFoundError:
+                err = "secret not found"
+        else:
+            err = "invalid secret name"
+        return {
+            "error": err,
+            "secret": secret,
+            }, 200
+
+    return app

--- a/secretserver/docker/secretserver/requirements.txt
+++ b/secretserver/docker/secretserver/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+gunicorn==23.0.0

--- a/secretserver/templates/asecretserver.yaml
+++ b/secretserver/templates/asecretserver.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: asecretserver-passwords
+data:
+  # {{- range $key, $value := .Values.secrets}}
+  {{$key}}: {{$value}}
+  # {{- end}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: asecretserver
+  labels:
+    app: atestapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atestapp-secretserver
+  template:
+    # no apiVersion or kind
+    metadata:
+      labels:
+        app: atestapp-secretserver
+    spec:
+      containers:
+        - name: asecretserver
+          image: "zannen/secretserver:{{.Values.secretserverVersion}}"
+          imagePullPolicy: Never
+          command:
+            - gunicorn
+            - --bind
+            - 0.0.0.0:80
+            - --access-logfile
+            - "-"  # Print to stdout
+            - --capture-output
+            - app:create_app()
+          ports:
+            - containerPort: 80
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            failureThreshold: 6
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 0
+            failureThreshold: 2
+            periodSeconds: 60
+          volumeMounts:
+            - mountPath: /var/run/passwords
+              name: volume-passwords
+              readOnly: true
+      volumes:
+        - name: volume-passwords
+          secret:
+            secretName: asecretserver-passwords
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: asecretserver
+  labels:
+    app: atestapp
+spec:
+  ports:
+    - protocol: TCP
+      targetPort: 80   # in container
+      port: 8880       # across cluster on ClusterIP
+      nodePort: 30880  # from outside cluster
+  selector:
+    app: atestapp-secretserver
+  type: NodePort

--- a/secretserver/values-secret-SAMPLE.yaml
+++ b/secretserver/values-secret-SAMPLE.yaml
@@ -1,0 +1,6 @@
+---
+# These are the secrets to be served. They are base64-encoded.
+# They will appear at /var/run/passwords/{secret_name} in the app container.
+secrets:
+  superSecretPassword1: czNjcmV0  # "s3cret"
+  superSecretPassword2: cGE1NXdvcmQ=  # "pa55word"

--- a/secretserver/values.yaml
+++ b/secretserver/values.yaml
@@ -1,0 +1,2 @@
+---
+secretserverVersion: "0.0.1"

--- a/webserver/README.md
+++ b/webserver/README.md
@@ -17,7 +17,7 @@ Get a minikube VM started, then:
 # Point your shell to minikube's docker-daemon:
 eval $(minikube docker-env)
 
-helm install atestapp . -n YOUR_NAMESPACE_HERE --create-namespace
+helm install atestapp . -n YOUR_NAMESPACE_HERE --create-namespace -f values.yaml
 ```
 
 # Getting pages on the webserver


### PR DESCRIPTION
This PR adds a simple secret server.

Secrets are read from `values-secret.yaml` and mounted in the secretserver container.

Closes #5